### PR TITLE
WIP: Add CB3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,56 +1,41 @@
-# This file was generated automatically from conda-smithy. To update this configuration,
-# update the conda-forge.yml and/or the recipe/meta.yaml.
+# The language in this case has no bearing - we are going to be making use of "conda" for a
+# python distribution for the scientific python stack.
+language: c
 
-language: generic
+os:
+  - linux
+  - osx
 
-os: osx
 osx_image: xcode6.4
 
 env:
-  global:
-    # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
-    - secure: "y63EWXqcbfBd9xMv0jjSzKuq+bSsuRkmJ5IUF8obpZ2thEXDQznNTWZspnf8v+4qj/NvN2+81py6qfuJeoH38PftAdcavHcwAJertkFzf55/q8aNy9V1MYvJCEekO6CDwSRhJERa95lBu7nixXRogI80fRr5F1fYLnDZzhBROZuS7UmNlyYy4a0c5oK4jbSkpIIdu52a4czDyzmadhDb3GTB7P+DaURuiR50kR7uI+so+dB0Ja40SevvRRkMIzoQyHyjwTNP5wJ5+XcizxhNzeMTOa1MoeMPKRGMyJV5L9xYROINq1QPuwo0x5kYB7bCBd6cE5vRWwq/ZKoI1B6oyBe5dkwKCfAEMxgnsMW7lgoiGaZyIZ0E1ZQQnSgRgnJKrEM6BqqpwIDnFBMCx1GYnTUJLJwULeYN0NV+mxGZqh7DoVIyEdvUCV1G4bOqgXZhar3Jtq9Fd8iB4SFVatkMvDOjLZZuFb1wg0/C1RBo+c+dnchqCBbNAHX1sva7e+WFYIsjySKX7jlIHus63TYVv/PW2OG0mtpMA9jK/ZmsDIsJt9mIWLM+7bFSHLOFpCkhRrj4V8F294n/t9oLBj/E/eTgIsNMZCMcO5+xaDFSJ9gKvCQQ3L/li5poVWawylbrM5f49c1A8PVuWInC+1flh0epyXywCuhKbUU0Yhv2SNQ="
+    matrix:
+        - PYTHON_VERSION=3.6
 
-
-before_install:
-    # Fast finish the PR.
-    - |
-      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
-          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
-
-    # Remove homebrew.
-    - |
-      echo ""
-      echo "Removing homebrew from Travis CI to avoid conflicts."
-      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
-      chmod +x ~/uninstall_homebrew
-      ~/uninstall_homebrew -fq
-      rm ~/uninstall_homebrew
-
+    global:
+        - TARGET_ARCH="x64"
+        - CONDA_INSTALL_LOCN="${HOME}/miniconda"
 
 install:
-    # Install Miniconda.
-    - |
-      echo ""
-      echo "Installing a fresh version of Miniconda."
-      MINICONDA_URL="https://repo.continuum.io/miniconda"
-      MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
-      bash $MINICONDA_FILE -b
+    # Install and set up miniconda.
+    - if [ $TRAVIS_OS_NAME == "linux" ]; then wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
+    - if [ $TRAVIS_OS_NAME == "osx" ]; then wget http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
+    - bash miniconda.sh -b -p $CONDA_INSTALL_LOCN
+    - export PATH=${CONDA_INSTALL_LOCN}/bin:$PATH
+    - conda config --set always_yes true
 
-    # Configure conda.
-    - |
-      echo ""
-      echo "Configuring conda."
-      source /Users/travis/miniconda3/bin/activate root
-      conda config --remove channels defaults
-      conda config --add channels defaults
-      #conda config --add channels conda-forge
-      conda config --set show_channel_urls true
-      #conda install --yes --quiet conda-forge-build-setup
-      #source run_conda_forge_build_setup
-      conda install -y conda-build # update to conda-build-3
+    # pin conda verson to 4.3.22
+    #- conda config --set auto_update_conda False
+    #- echo "conda ==4.3.22" >> ${CONDA_INSTALL_LOCN}/conda-meta/pinned
+
+    - conda install --quiet conda
+
+    # latest conda build
+    - conda install 'conda-build'
+
+    # To ease debugging, list installed packages
+    - conda info -a
+    - conda list
 script:
-  - conda build ./recipe
-
-  #- upload_or_check_non_existence ./recipe conda-forge --channel=main
+    - |
+       conda build recipe;

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
       conda config --set show_channel_urls true
       #conda install --yes --quiet conda-forge-build-setup
       #source run_conda_forge_build_setup
-      conda update -y conda-build # update to conda-build-3
+      conda install -y conda-build # update to conda-build-3
 script:
   - conda build ./recipe
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,12 +45,12 @@ install:
       source /Users/travis/miniconda3/bin/activate root
       conda config --remove channels defaults
       conda config --add channels defaults
-      conda config --add channels conda-forge
+      #conda config --add channels conda-forge
       conda config --set show_channel_urls true
-      conda install --yes --quiet conda-forge-build-setup
-      source run_conda_forge_build_setup
+      #conda install --yes --quiet conda-forge-build-setup
+      #source run_conda_forge_build_setup
       conda update -y conda-build # update to conda-build-3
 script:
   - conda build ./recipe
 
-  - upload_or_check_non_existence ./recipe conda-forge --channel=main
+  #- upload_or_check_non_existence ./recipe conda-forge --channel=main

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup
       source run_conda_forge_build_setup
-
+      conda update -y conda-build # update to conda-build-3
 script:
   - conda build ./recipe
 

--- a/check-glibc.sh
+++ b/check-glibc.sh
@@ -1,0 +1,26 @@
+#! /bin/bash
+
+set -e
+if ! [ -d $1 ]; then
+    echo Folder $1 does not exist -- did you give a wrong destination or forget --single-version-externally-managed
+    exit 1
+fi
+
+fns=`find $1 -name '*.so'`
+for fn in $fns; do
+    echo "--- GLIBC symbols in $fn --"
+    objdump -T $fn | grep GLIBC | awk '
+        BEGIN { bad = 0 }
+        {print $0}
+        /GLIBC_2\.1[3-9]/ {
+            bad = 1
+        }
+        /GLIBC_2\.[2-9][0-9]/ {
+            bad = 1
+        }
+        END {
+            if (bad) print("Bad symbols detected");
+            exit bad;
+        }
+    '
+done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,8 +2,11 @@
 
 # since we are doing cross compilation
 # configure will fail
+if [[ $OSTYPE == darwin* ]]; then
+    export LDFLAGS="$LDFLAGS -Wl,-rpath,${CONDA_PREFIX}/lib"
+fi
 
-export CROSS_F77_SIZEOF_INTEGER=4
+export FCFLAGS="$FFLAGS"
 
 ./configure --prefix=$PREFIX \
             --disable-dependency-tracking \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-if [ $(uname) == Darwin ]; then
-    export LDFLAGS="$LDFLAGS -Wl,-rpath,$PREFIX/lib"
-fi
-
-export LIBRARY_PATH="$PREFIX/lib"
-
 ./configure --prefix=$PREFIX \
             --disable-dependency-tracking \
             --enable-cxx \
@@ -13,3 +7,8 @@ export LIBRARY_PATH="$PREFIX/lib"
 
 make
 make install
+
+if [[ $OSTYPE != darwin* ]]; then
+    cp $RECIPE_DIR/../check-glibc.sh .
+    bash check-glibc.sh $PREFIX/lib/ || exit 1
+fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,9 @@ export CROSS_F77_SIZEOF_INTEGER=4
 ./configure --prefix=$PREFIX \
             --disable-dependency-tracking \
             --enable-cxx \
-            --enable-fortran
+            --enable-f77 \
+            --enable-fc #\
+#            --with-cross=$RECIPE_DIR/cross.conf
 
 make -j$CPU_COUNT
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# since we are doing cross compilation
+# configure will fail
+
+export CROSS_F77_SIZEOF_INTEGER=4
+
 ./configure --prefix=$PREFIX \
             --disable-dependency-tracking \
             --enable-cxx \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-# since we are doing cross compilation
-# configure will fail
 if [[ $OSTYPE == darwin* ]]; then
+    # this may need to be done on linux too,
+    # see https://github.com/ContinuumIO/anaconda-issues/issues/739
     export LDFLAGS="$LDFLAGS -Wl,-rpath,${CONDA_PREFIX}/lib"
 fi
 
+# don't know if this is useful.
 export FCFLAGS="$FFLAGS"
 
 ./configure --prefix=$PREFIX \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@
             --enable-cxx \
             --enable-fortran
 
-make
+make -j$CPU_COUNT
 make install
 
 if [[ $OSTYPE != darwin* ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,12 @@ requirements:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         - {{ compiler("fortran") }}
-
 test:
+    requires:
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
+        - {{ compiler("fortran") }}
+
     files:
         - tests/helloworld.c
         - tests/helloworld.cxx

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,3 +50,4 @@ extra:
         - minrk
         - msarahan
         - ocefpaf
+        - rainwoodman

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,20 +10,16 @@ source:
     sha256: 0778679a6b693d7b7caff37ff9d2856dc2bfc51318bf8373859bfa74253da3dc
 
 build:
-    number: 5
+    number: 6
     skip: True  # [win]
 
 requirements:
     build:
-        - gcc  # [not win]
-        - toolchain
-    run:
-        - libgcc  # [linux]
-        - libgfortran  # [osx]
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
+        - {{ compiler("fortran") }}
 
 test:
-    requires:
-        - gcc  # [not win]
     files:
         - tests/helloworld.c
         - tests/helloworld.cxx


### PR DESCRIPTION
This PR provides mpich package on both OSX and Linux. See the travis build log here.

https://travis-ci.org/rainwoodman/mpich-feedstock/builds/305635086

I linked our packages and mpi4py against this binary on Linux and it worked well.

The current anaconda provides a mpich2 package that conflicts with this one. 