### PR TITLE
mpich 4.1.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_parameters:
+  - ""

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,6 @@
 build_parameters:
+  # Disable --error-overlinking because of an error:
+  # `lib/libmpifort.so.12.3.0: but '_openmp_mutex' not in reqs/run`
   - ""
 
 upload_channels:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-build_parameters:
-  # Disable --error-overlinking because of an error:
-  # `lib/libmpifort.so.12.3.0: but '_openmp_mutex' not in reqs/run`
-  - ""

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,9 +2,3 @@ build_parameters:
   # Disable --error-overlinking because of an error:
   # `lib/libmpifort.so.12.3.0: but '_openmp_mutex' not in reqs/run`
   - ""
-
-upload_channels:
-  - sk_test
-
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,8 @@
 build_parameters:
   - ""
+
+upload_channels:
+  - sk_test
+
+channels:
+  - sk_test

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -64,12 +64,12 @@ export LDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 export LIBRARY_PATH="$PREFIX/lib"
 export MPICH_AUTOTOOLS_DIR="${BUILD_PREFIX}/bin"
 
-./autogen.sh
-
 # Allow argument mismatch in Fortran
 # https://github.com/pmodels/mpich/issues/4300
 export FFLAGS="$FFLAGS -fallow-argument-mismatch"
 export FCFLAGS="$FCFLAGS -fallow-argument-mismatch"
+
+./autogen.sh
 
 ./configure --prefix=$PREFIX \
             --disable-dependency-tracking \

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -13,7 +13,7 @@ export CC=$(basename "$CC")
 export CXX=$(basename "$CXX")
 export FC=$(basename "$FC")
 
-if [[ $target_platform == "osx-*" ]]; then
+if [[ "$(uname)" == "Darwin" ]]; then
     # Fix perl locale settings on osx
     export LANGUAGE=en_US.UTF-8
     export LC_ALL=en_US.UTF-8

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -21,6 +21,12 @@ if [[ $target_platform == osx-arm64 ]]; then
     done
 fi
 
+if [[ "$target_platform" == "linux-ppc64le" ]]; then
+    # Fix symbol relocation errors
+    export CFLAGS="$CFLAGS -fplt"
+    export CXXFLAGS="$CXXFLAGS -fplt"
+fi
+
 # avoid recording flags in compilers
 # See Compiler Flags section of MPICH readme
 # TODO: configure ignores MPICHLIB_LDFLAGS
@@ -62,7 +68,8 @@ fi
             --enable-shared \
             --enable-cxx \
             --enable-fortran \
-            --disable-wrapper-rpath
- 
+            --disable-wrapper-rpath \
+            || cat config.log
+
 make -j"${CPU_COUNT:-1}"
 make install

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -14,6 +14,9 @@ export CXX=$(basename "$CXX")
 export FC=$(basename "$FC")
 
 if [[ $target_platform == osx-arm64 ]]; then
+    export LC_CTYPE="C.UTF-8"
+    export LC_ALL="C.UTF-8"
+    
     list_config_to_patch=$(find . -name config.guess | sed -E 's/config.guess//')
     for config_folder in $list_config_to_patch; do
         echo "copying config to $config_folder ...\n"
@@ -57,9 +60,10 @@ export MPICH_AUTOTOOLS_DIR="${BUILD_PREFIX}/bin"
 
 ./autogen.sh
 
-if [[ $target_platform == osx-arm64 ]]; then
-  export FFLAGS="${FFLAGS} -fallow-argument-mismatch"
-fi
+# Allow argument mismatch in Fortran
+# https://github.com/pmodels/mpich/issues/4300
+export FFLAGS="$FFLAGS -fallow-argument-mismatch"
+export FCFLAGS="$FCFLAGS -fallow-argument-mismatch"
 
 ./configure --prefix=$PREFIX \
             --disable-dependency-tracking \
@@ -68,8 +72,7 @@ fi
             --enable-shared \
             --enable-cxx \
             --enable-fortran \
-            --disable-wrapper-rpath \
-            || cat config.log
+            --disable-wrapper-rpath
 
 make -j"${CPU_COUNT:-1}"
 make install

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -14,8 +14,10 @@ export CXX=$(basename "$CXX")
 export FC=$(basename "$FC")
 
 if [[ $target_platform == osx-arm64 ]]; then
-    export LC_CTYPE="C.UTF-8"
-    export LC_ALL="C.UTF-8"
+    export LANGUAGE=en_US.UTF-8
+    export LC_ALL=en_US.UTF-8
+    export LANG=en_US.UTF-8
+    export LC_CTYPE=en_US.UTF-8
     
     list_config_to_patch=$(find . -name config.guess | sed -E 's/config.guess//')
     for config_folder in $list_config_to_patch; do

--- a/recipe/build-mpi.sh
+++ b/recipe/build-mpi.sh
@@ -13,11 +13,15 @@ export CC=$(basename "$CC")
 export CXX=$(basename "$CXX")
 export FC=$(basename "$FC")
 
-if [[ $target_platform == osx-arm64 ]]; then
+if [[ $target_platform == "osx-*" ]]; then
+    # Fix perl locale settings on osx
     export LANGUAGE=en_US.UTF-8
     export LC_ALL=en_US.UTF-8
     export LANG=en_US.UTF-8
     export LC_CTYPE=en_US.UTF-8
+fi
+
+if [[ $target_platform == osx-arm64 ]]; then
     
     list_config_to_patch=$(find . -name config.guess | sed -E 's/config.guess//')
     for config_folder in $list_config_to_patch; do

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,3 @@
 mpi_type:
   - external
   - conda
-# this hack is required for libtool on arm64, which doesn't know about 11.x deployment targets ...
-MACOSX_DEPLOYMENT_TARGET:  # [osx and arm64]
-  - 10.15                  # [osx and arm64]
-CONDA_BUILD_SYSROOT:        # [osx and arm64]
-  - /opt/MacOSX10.15.sdk    # [osx and arm64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,3 +4,5 @@ mpi_type:
 # this hack is required for libtool on arm64, which doesn't know about 11.x deployment targets ...
 MACOSX_DEPLOYMENT_TARGET:  # [osx and arm64]
   - 10.15                  # [osx and arm64]
+CONDA_BUILD_SYSROOT:        # [osx and arm64]
+  - /opt/MacOSX10.15.sdk    # [osx and arm64]

--- a/recipe/libfrabric-osx-lock.patch
+++ b/recipe/libfrabric-osx-lock.patch
@@ -1,0 +1,19 @@
+--- a/modules/libfabric/include/osx/osd.h
++++ b/modules/libfabric/include/osx/osd.h
+@@ -167,7 +167,17 @@ ssize_t ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags);
+  * os_unfair_lock does not enforce fairness or lock ordering (hence
+  * the name unfair), which is similar to pthread_spinlock.
+  */
++#include <Availability.h>
++#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
+ #include <os/lock.h>
++#else
++#include <libkern/OSAtomic.h>
++#define OS_UNFAIR_LOCK_INIT OS_SPINLOCK_INIT
++#define os_unfair_lock OSSpinLock
++#define os_unfair_lock_lock OSSpinLockLock
++#define os_unfair_lock_trylock OSSpinLockTry
++#define os_unfair_lock_unlock OSSpinLockUnlock
++#endif
+ 
+ typedef os_unfair_lock pthread_spinlock_t;

--- a/recipe/libfrabric-osx-memsize.patch
+++ b/recipe/libfrabric-osx-memsize.patch
@@ -1,0 +1,34 @@
+--- a/modules/libfabric/src/mem.c
++++ b/modules/libfabric/src/mem.c
+@@ -104,6 +104,23 @@ void ofi_mem_fini(void)
+ 	free(page_sizes);
+ }
+ 
++#if defined(__APPLE__) && !defined(_SC_PHYS_PAGES)
++
++#include <sys/sysctl.h>
++
++size_t ofi_get_mem_size(void)
++{
++	uint64_t mem_size;
++	size_t len;
++
++	len = sizeof(mem_size);
++	sysctlbyname("hw.memsize", &mem_size, &len, NULL, 0);
++
++	return (size_t) mem_size;
++}
++
++#else
++
+ size_t ofi_get_mem_size(void)
+ {
+ 	long page_cnt, page_size;
+@@ -122,6 +139,7 @@ size_t ofi_get_mem_size(void)
+ 	return mem_size;
+ }
+ 
++#endif
+ 
+ uint64_t OFI_RMA_PMEM;
+ void (*ofi_pmem_commit)(const void *addr, size_t len);

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ outputs:
         - libtool   # [unix]
         - automake  # [unix]
         - autoconf  # [unix]
+        - patch     # [unix]
       host: []
       run:
         - mpi 1.0 mpich

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,8 @@ outputs:
       host: []
       run:
         - mpi 1.0 mpich
+        # lib/libmpifort.so.12.3.0 requires _openmp_mutex on linux
+        - _openmp_mutex  # [linux]
     test:
       script: run_test.sh
       files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,9 +15,9 @@ package:
 source:
   url: https://www.mpich.org/static/downloads/{{ version_url }}/mpich-{{ version_url }}.tar.gz
   sha256: ee30471b35ef87f4c88f871a5e2ad3811cd9c4df32fd4f138443072ff4284ca2
-  patches:
-    - libfrabric-osx-lock.patch
-    - libfrabric-osx-memsize.patch
+  patches:                          # [osx]
+    - libfrabric-osx-lock.patch     # [osx]
+    - libfrabric-osx-memsize.patch  # [osx]
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ source:
   patches:
     - libfrabric-osx-lock.patch
     - libfrabric-osx-memsize.patch
+
 build:
   number: {{ build }}
   skip: True  # [win]
@@ -40,6 +41,8 @@ outputs:
     build:
       run_exports:
         - {{ pin_subpackage('mpich', max_pin='x') }}
+      missing_dso_whitelist:  # [linux and s390x]
+        - "$RPATH/ld64.so.1"  # [linux and s390x]
     requirements:
       build:
         - {{ compiler('c') }}
@@ -65,7 +68,7 @@ outputs:
         - echo 'ok'  # [not osx]
         # make CONDA_BUILD_SYSROOT a 'used variable'
         # so that conda-build knows to pass it to the test env
-        - echo "{{CONDA_BUILD_SYSROOT}}"  # [osx]
+        - echo "{{ CONDA_BUILD_SYSROOT }}"  # [osx]
     requirements:
       run:
         - {{ pin_subpackage('mpich', exact=True) }}
@@ -83,7 +86,7 @@ outputs:
         - echo 'ok'  # [not osx]
         # make CONDA_BUILD_SYSROOT a 'used variable'
         # so that conda-build knows to pass it to the test env
-        - echo "{{CONDA_BUILD_SYSROOT}}"  # [osx]
+        - echo "{{ CONDA_BUILD_SYSROOT }}"  # [osx]
     requirements:
       run:
         - {{ pin_subpackage('mpich', exact=True) }}
@@ -101,7 +104,7 @@ outputs:
         - echo 'ok'  # [not osx]
         # make CONDA_BUILD_SYSROOT a 'used variable'
         # so that conda-build knows to pass it to the test env
-        - echo "{{CONDA_BUILD_SYSROOT}}"  # [osx]
+        - echo "{{ CONDA_BUILD_SYSROOT }}"  # [osx]
     requirements:
       run:
         - {{ pin_subpackage('mpich', exact=True) }}
@@ -135,3 +138,6 @@ extra:
     - msarahan
     - ocefpaf
     - beckermr
+  skip-lints:
+    - compilers_must_be_in_build
+    - patch_must_be_in_build

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,11 @@
-{% set version = "3.3.2" %}
+{% set version = "4.1.1" %}
 {% set build = 0 %}
+
+{% if version.rpartition(".")[2] == "0" %}
+{% set version_url = version.rpartition(".")[0] %}
+{% else %}
+{% set version_url = version %}
+{% endif %}
 
 package:
   # must not match any outputs for requirements to be handled correctly
@@ -7,10 +13,11 @@ package:
   version: {{ version }}
 
 source:
-  fn: mpich-{{ version }}.tar.gz
-  url: http://www.mpich.org/static/downloads/{{ version }}/mpich-{{ version }}.tar.gz
-  sha256: 4bfaf8837a54771d3e4922c84071ef80ffebddbb6971a006038d91ee7ef959b9
-
+  url: https://www.mpich.org/static/downloads/{{ version_url }}/mpich-{{ version_url }}.tar.gz
+  sha256: ee30471b35ef87f4c88f871a5e2ad3811cd9c4df32fd4f138443072ff4284ca2
+  patches:
+    - libfrabric-osx-lock.patch
+    - libfrabric-osx-memsize.patch
 build:
   number: {{ build }}
   skip: True  # [win]
@@ -32,9 +39,7 @@ outputs:
     script: build-mpi.sh
     build:
       run_exports:
-        - {{ pin_subpackage('mpich', max_pin='x.x') }}
-      missing_dso_whitelist:                                              # [osx]
-        - /System/Library/Frameworks/OpenCL.framework/Versions/A/OpenCL   # [osx]
+        - {{ pin_subpackage('mpich', max_pin='x') }}
     requirements:
       build:
         - {{ compiler('c') }}
@@ -109,16 +114,16 @@ outputs:
   {% endif %}
 
 about:
-  home: http://www.mpich.org/
-  license: MPICH
+  home: https://www.mpich.org/
+  license: LicenseRef-MPICH
   license_file: COPYRIGHT
   license_family: Other
-  summary: 'A high performance widely portable implementation of the MPI standard.'
+  summary: A high performance widely portable implementation of the MPI standard.
   description: |
     MPICH is a high performance and widely portable implementation of the
     Message Passing Interface (MPI) standard.
-  doc_url: http://www.mpich.org/documentation/guides
-  dev_url: https://wiki.mpich.org/mpich/index.php/Main_Page
+  doc_url: https://www.mpich.org/documentation/guides
+  dev_url: https://github.com/pmodels/mpich
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ outputs:
         - libtool   # [unix]
         - automake  # [unix]
         - autoconf  # [unix]
-        - patch     # [unix]
+        - patch     # [osx]
         - perl      # [unix]
       host: []
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,7 @@ outputs:
         - automake  # [unix]
         - autoconf  # [unix]
         - patch     # [unix]
+        - perl      # [unix]
       host: []
       run:
         - mpi 1.0 mpich


### PR DESCRIPTION
Changelog: https://github.com/pmodels/mpich/blob/v4.1.1/CHANGES
License: https://github.com/pmodels/mpich/blob/v4.1.1/COPYRIGHT
Requirements:
- https://github.com/pmodels/mpich/tree/v4.1.1
- https://github.com/pmodels/mpich/blob/v4.1.1/autogen.sh
- https://github.com/pmodels/mpich/blob/v4.1.1/configure.ac

Actions:
1. Fix perl locale settings on `osx`. In logs, there were warnings (not errors) on `osx` but the build failed anyway
2. Add `-fplt` flag for `ppc64le` (following the conda-forge recipe)
3. Enable `-fallow-argument-mismatch` flag for all platforms (see c-f recipe)
4. Remove `MACOSX_DEPLOYMENT_TARGET` because it fails
5. Add two new patches for `osx` (following the conda-forge recipe)
6. Add `missing_dso_whitelist` for `s390x` (a known issue for this platform)
7. Add `patch` and `perl` to `build`. Perl is required https://github.com/pmodels/mpich/blob/27df1e04b291dae3d664174f6dfe949c5b83c6e3/README.vin#L51
8.  Add '_openmp_mutex' to `run` on `linux` because `lib/libmpifort.so.12.3.0` requires it
9. Fix home, dev & doc urls
10. Update `license` name
11. Skip lints
